### PR TITLE
Modificación de .gitignore para subir archivos aplication properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ target/
 *.class
 *.log
 /bin/
-/src/main/resources/*.properties
 *~
 .DS_Store
 *.swp

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,13 @@
+# Configuración específica para desarrollo
+springdoc.swagger-ui.path=/swagger-ui
+springdoc.swagger-ui.enabled=true
+springdoc.api-docs.enabled=true
+
+# Configuración adicional para desarrollo
+springdoc.swagger-ui.default-models-expand-depth=1
+springdoc.swagger-ui.default-model-expand-depth=1
+springdoc.swagger-ui.display-request-duration=true
+springdoc.swagger-ui.filter=true
+
+# Mostrar más detalles en desarrollo
+logging.level.org.springdoc=DEBUG

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,10 @@
+# Configuración segura para producción
+# SIN INTERFAZ pero CON documentación JSON en producción
+springdoc.swagger-ui.path=/docs
+# ? SIN interfaz visual
+springdoc.swagger-ui.enabled=false
+# ? PERO SÍ documentación para herramientas
+springdoc.api-docs.enabled=true
+
+# Seguridad adicional - solo mostrar endpoints públicos
+springdoc.paths-to-exclude=/admin/**, /internal/**

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,3 @@
+# Swagger deshabilitado en pruebas para mejor rendimiento
+springdoc.swagger-ui.enabled=false
+springdoc.api-docs.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+spring.application.name=QZ-Workhub
+# Configuración básica de OpenAPI (común a todos los entornos)
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha
+springdoc.swagger-ui.tryItOutEnabled=true
+springdoc.swagger-ui.doc-expansion=none
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.show-actuator=false
+springdoc.paths-to-match=/api/**


### PR DESCRIPTION
Se quito limitante del gitignore para poder subir los aplications properties dev-prod-test y normal
<img width="236" height="280" alt="image" src="https://github.com/user-attachments/assets/ded30b62-0455-4f8a-a98f-ef37638b2b13" />
